### PR TITLE
Update to grape 1.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'grape', '~> 1.0'
+gem 'grape', '~> 1.4'
 gem 'rack-oauth2'
 
 gem 'activerecord'

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you are using bundler, first add `'grape_oauth2'` to your Gemfile:
 
 ```ruby
 
-gem 'grape', '~> 1.0'
+gem 'grape', '~> 1.4'
 gem 'grape_oauth2', '~> 0.2'
 
 # or

--- a/lib/grape_oauth2/responses/base.rb
+++ b/lib/grape_oauth2/responses/base.rb
@@ -40,7 +40,7 @@ module Grape
 
         # Raw Rack body
         def raw_body
-          @rack_response[2].body
+          @rack_response[2]
         end
 
         # JSON-parsed body


### PR DESCRIPTION
Having troubles running this on grape 1.4.0 as the base response complains on

```
NoMethodError:
        undefined method `body' for #<Array:0x00000000046366a0>
```

It seems like the response changed and the second position of rack response now returns body directly (not a response object)

Tests are passing and works with my rails app using grape 1.4